### PR TITLE
Fix stale cached PreparedStatements and duplicate batch inserts

### DIFF
--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/BatchProcessor.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/BatchProcessor.java
@@ -51,56 +51,52 @@ public class BatchProcessor<T> {
   }
 
   /**
-   * Adds an item to the batch. Automatically flushes if batch size is reached.
+   * Adds an item to the batch. Does NOT auto-flush. Caller is responsible for calling flush() when
+   * ready.
    *
    * @param item The item to add
-   * @param statement The prepared statement to use for execution
-   * @throws SQLException if database operation fails
    */
-  public void add(T item, PreparedStatement statement) throws SQLException {
+  public void add(T item) {
     batch.add(item);
-
-    if (batch.size() >= batchSize) {
-      flush(statement);
-    }
   }
 
   /**
-   * Flushes any remaining items in the batch.
+   * Flushes items in the batch, processing in chunks of batchSize. This handles cases where the
+   * batch may have accumulated more items than batchSize. Only removes items from the batch after
+   * successful execution.
    *
    * @param statement The prepared statement to use for execution
    * @throws SQLException if database operation fails
    */
   public void flush(PreparedStatement statement) throws SQLException {
-    if (batch.isEmpty()) {
-      return;
-    }
-    try {
-      executeBatch(statement);
-    } catch (SQLException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new SQLException("Failed to execute batch", e);
-    }
-  }
+    while (!batch.isEmpty()) {
+      int itemsToFlush = Math.min(batch.size(), batchSize);
+      List<T> currentBatch = batch.subList(0, itemsToFlush);
 
-  /** Executes the current batch. */
-  private void executeBatch(PreparedStatement statement) throws SQLException {
-    for (T item : batch) {
-      statementSetter.accept(statement, item);
-      statement.addBatch();
+      // Execute this chunk
+      for (T item : currentBatch) {
+        statementSetter.accept(statement, item);
+        statement.addBatch();
+      }
+
+      statement.executeBatch();
+      statement.clearBatch();
+
+      log.debug("Executed batch of {} items", itemsToFlush);
+
+      // Only remove if successful
+      currentBatch.clear(); // Removes from original batch
     }
-
-    statement.executeBatch();
-    statement.clearBatch();
-
-    log.debug("Executed batch of {} items", batch.size());
-    batch.clear();
   }
 
   /** Returns the current number of items in the batch. */
   public int size() {
     return batch.size();
+  }
+
+  /** Returns true if the batch has reached the configured batch size and should be flushed. */
+  public boolean shouldFlush() {
+    return batch.size() >= batchSize;
   }
 
   /** Clears the batch without executing. */

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/ConnectionManager.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/ConnectionManager.java
@@ -38,12 +38,12 @@ public class ConnectionManager {
 
   private final BenchmarkModule benchmark;
   private final ConcurrentMap<String, Pair<Connection, Long>> connections;
-  private final ConcurrentMap<String, PreparedStatement> statements;
+  private final ConcurrentMap<String, ConcurrentMap<String, PreparedStatement>> statementsByThread;
 
   public ConnectionManager(BenchmarkModule benchmark) {
     this.benchmark = benchmark;
     this.connections = new ConcurrentHashMap<>();
-    this.statements = new ConcurrentHashMap<>();
+    this.statementsByThread = new ConcurrentHashMap<>();
   }
 
   /**
@@ -69,6 +69,22 @@ public class ConnectionManager {
 
   /** Refreshes the connection for a thread, closing the old one if it exists. */
   public void refreshConnection(String threadName) throws SQLException {
+    // Clear all statements for this thread FIRST
+    ConcurrentMap<String, PreparedStatement> threadStatements =
+        statementsByThread.remove(threadName);
+
+    if (threadStatements != null) {
+      threadStatements.forEach(
+          (tableName, stmt) -> {
+            try {
+              stmt.close();
+            } catch (SQLException e) {
+              log.error("Failed to close statement for {}/{}", threadName, tableName, e);
+            }
+          });
+    }
+
+    // Then refresh connection
     closeConnectionForThread(threadName);
     createConnection(threadName);
   }
@@ -76,13 +92,15 @@ public class ConnectionManager {
   /** Gets or creates a prepared statement for the given thread and table. */
   public PreparedStatement getPreparedStatement(String threadName, String tableName, String sql)
       throws SQLException {
-    String key = generateStatementKey(threadName, tableName);
-    PreparedStatement stmt = statements.get(key);
+    ConcurrentMap<String, PreparedStatement> threadStatements =
+        statementsByThread.computeIfAbsent(threadName, k -> new ConcurrentHashMap<>());
+
+    PreparedStatement stmt = threadStatements.get(tableName);
 
     if (stmt == null || stmt.isClosed()) {
       Connection conn = getConnection(threadName);
       stmt = conn.prepareStatement(sql);
-      statements.put(key, stmt);
+      threadStatements.put(tableName, stmt);
     }
 
     return stmt;
@@ -90,14 +108,16 @@ public class ConnectionManager {
 
   /** Closes a specific prepared statement. */
   public void closePreparedStatement(String threadName, String tableName) {
-    String key = generateStatementKey(threadName, tableName);
-    PreparedStatement stmt = statements.remove(key);
+    ConcurrentMap<String, PreparedStatement> threadStatements = statementsByThread.get(threadName);
 
-    if (stmt != null) {
-      try {
-        stmt.close();
-      } catch (SQLException e) {
-        log.error("Failed to close PreparedStatement for {}", key, e);
+    if (threadStatements != null) {
+      PreparedStatement stmt = threadStatements.remove(tableName);
+      if (stmt != null) {
+        try {
+          stmt.close();
+        } catch (SQLException e) {
+          log.error("Failed to close PreparedStatement for {}/{}", threadName, tableName, e);
+        }
       }
     }
   }
@@ -105,20 +125,19 @@ public class ConnectionManager {
   /** Closes all resources for a specific thread. */
   public void closeResourcesForThread(String threadName) {
     // Close all statements for this thread
-    statements
-        .entrySet()
-        .removeIf(
-            entry -> {
-              if (entry.getKey().startsWith(threadName)) {
-                try {
-                  entry.getValue().close();
-                } catch (SQLException e) {
-                  log.error("Failed to close statement: {}", entry.getKey(), e);
-                }
-                return true;
-              }
-              return false;
-            });
+    ConcurrentMap<String, PreparedStatement> threadStatements =
+        statementsByThread.remove(threadName);
+
+    if (threadStatements != null) {
+      threadStatements.forEach(
+          (tableName, stmt) -> {
+            try {
+              stmt.close();
+            } catch (SQLException e) {
+              log.error("Failed to close statement for {}/{}", threadName, tableName, e);
+            }
+          });
+    }
 
     // Close connection
     closeConnectionForThread(threadName);
@@ -127,15 +146,18 @@ public class ConnectionManager {
   /** Closes all connections and statements. */
   public void closeAll() {
     // Close all statements
-    statements.forEach(
-        (key, stmt) -> {
-          try {
-            stmt.close();
-          } catch (SQLException e) {
-            log.error("Failed to close statement: {}", key, e);
-          }
+    statementsByThread.forEach(
+        (threadName, threadStatements) -> {
+          threadStatements.forEach(
+              (tableName, stmt) -> {
+                try {
+                  stmt.close();
+                } catch (SQLException e) {
+                  log.error("Failed to close statement for {}/{}", threadName, tableName, e);
+                }
+              });
         });
-    statements.clear();
+    statementsByThread.clear();
 
     // Close all connections
     connections.forEach(
@@ -166,9 +188,5 @@ public class ConnectionManager {
 
   private boolean isConnectionExpired(Pair<Connection, Long> connectionPair) {
     return System.currentTimeMillis() - connectionPair.second >= SESSION_DURATION;
-  }
-
-  private String generateStatementKey(String threadName, String tableName) {
-    return threadName + "_" + tableName;
   }
 }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/CustomerTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/CustomerTableLoader.java
@@ -70,14 +70,18 @@ public class CustomerTableLoader extends AbstractTableLoader {
     for (int d = 1; d <= districtsPerWarehouse; d++) {
       for (int c = 1; c <= customersPerDistrict; c++) {
         Customer customer = generateCustomer(warehouseId, d, c);
+        batchProcessor.add(customer);
 
-        executeWithRetry(
-            () -> {
-              PreparedStatement stmt = getInsertStatement(threadName);
-              batchProcessor.add(customer, stmt);
-            },
-            threadName,
-            "Insert Customer");
+        // Flush when batch is full
+        if (batchProcessor.shouldFlush()) {
+          executeWithRetry(
+              () -> {
+                PreparedStatement stmt = getInsertStatement(threadName);
+                batchProcessor.flush(stmt);
+              },
+              threadName,
+              "Flush customers batch");
+        }
       }
     }
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/HistoryTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/HistoryTableLoader.java
@@ -72,14 +72,18 @@ public class HistoryTableLoader extends AbstractTableLoader {
     for (int d = 1; d <= districtsPerWarehouse; d++) {
       for (int c = 1; c <= customersPerDistrict; c++) {
         History history = generateHistory(warehouseId, d, c);
+        batchProcessor.add(history);
 
-        executeWithRetry(
-            () -> {
-              PreparedStatement stmt = getInsertStatement(threadName);
-              batchProcessor.add(history, stmt);
-            },
-            threadName,
-            "Insert History");
+        // Flush when batch is full
+        if (batchProcessor.shouldFlush()) {
+          executeWithRetry(
+              () -> {
+                PreparedStatement stmt = getInsertStatement(threadName);
+                batchProcessor.flush(stmt);
+              },
+              threadName,
+              "Flush history batch");
+        }
       }
     }
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/ItemTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/ItemTableLoader.java
@@ -61,14 +61,18 @@ public class ItemTableLoader extends AbstractTableLoader {
 
     for (int i = 1; i <= itemCount; i++) {
       Item item = generateItem(i);
+      batchProcessor.add(item);
 
-      executeWithRetry(
-          () -> {
-            PreparedStatement stmt = getInsertStatement(threadName);
-            batchProcessor.add(item, stmt);
-          },
-          threadName,
-          "Insert Item");
+      // Flush when batch is full
+      if (batchProcessor.shouldFlush()) {
+        executeWithRetry(
+            () -> {
+              PreparedStatement stmt = getInsertStatement(threadName);
+              batchProcessor.flush(stmt);
+            },
+            threadName,
+            "Flush items batch");
+      }
     }
 
     // Flush any remaining items

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/NewOrderTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/NewOrderTableLoader.java
@@ -85,13 +85,18 @@ public class NewOrderTableLoader extends AbstractTableLoader {
           newOrder.no_d_id = d;
           newOrder.no_o_id = c;
 
-          executeWithRetry(
-              () -> {
-                PreparedStatement stmt = getInsertStatement(threadName);
-                batchProcessor.add(newOrder, stmt);
-              },
-              threadName,
-              "Insert New Order");
+          batchProcessor.add(newOrder);
+
+          // Flush when batch is full
+          if (batchProcessor.shouldFlush()) {
+            executeWithRetry(
+                () -> {
+                  PreparedStatement stmt = getInsertStatement(threadName);
+                  batchProcessor.flush(stmt);
+                },
+                threadName,
+                "Flush new orders batch");
+          }
         }
       }
     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/OrderLineTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/OrderLineTableLoader.java
@@ -83,14 +83,18 @@ public class OrderLineTableLoader extends AbstractTableLoader {
 
         for (int l = 1; l <= orderLineCount; l++) {
           OrderLine orderLine = generateOrderLine(warehouseId, d, c, l);
+          batchProcessor.add(orderLine);
 
-          executeWithRetry(
-              () -> {
-                PreparedStatement stmt = getInsertStatement(threadName);
-                batchProcessor.add(orderLine, stmt);
-              },
-              threadName,
-              "Insert Order Line");
+          // Flush when batch is full
+          if (batchProcessor.shouldFlush()) {
+            executeWithRetry(
+                () -> {
+                  PreparedStatement stmt = getInsertStatement(threadName);
+                  batchProcessor.flush(stmt);
+                },
+                threadName,
+                "Flush order lines batch");
+          }
         }
       }
     }

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/OrderTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/OrderTableLoader.java
@@ -78,14 +78,18 @@ public class OrderTableLoader extends AbstractTableLoader {
 
       for (int c = 1; c <= customersPerDistrict; c++) {
         Oorder order = generateOrder(warehouseId, d, c, c_ids[c - 1]);
+        batchProcessor.add(order);
 
-        executeWithRetry(
-            () -> {
-              PreparedStatement stmt = getInsertStatement(threadName);
-              batchProcessor.add(order, stmt);
-            },
-            threadName,
-            "Insert Order");
+        // Flush when batch is full
+        if (batchProcessor.shouldFlush()) {
+          executeWithRetry(
+              () -> {
+                PreparedStatement stmt = getInsertStatement(threadName);
+                batchProcessor.flush(stmt);
+              },
+              threadName,
+              "Flush orders batch");
+        }
       }
     }
 

--- a/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/StockTableLoader.java
+++ b/src/main/java/com/oltpbenchmark/benchmarks/tpcc/custom/auroradsql/loaders/StockTableLoader.java
@@ -67,14 +67,18 @@ public class StockTableLoader extends AbstractTableLoader {
 
     for (int i = 1; i <= numItems; i++) {
       Stock stock = generateStock(warehouseId, i);
+      batchProcessor.add(stock);
 
-      executeWithRetry(
-          () -> {
-            PreparedStatement stmt = getInsertStatement(threadName);
-            batchProcessor.add(stock, stmt);
-          },
-          threadName,
-          "Insert Stock");
+      // Flush when batch is full
+      if (batchProcessor.shouldFlush()) {
+        executeWithRetry(
+            () -> {
+              PreparedStatement stmt = getInsertStatement(threadName);
+              batchProcessor.flush(stmt);
+            },
+            threadName,
+            "Flush stocks batch");
+      }
     }
 
     // Flush any remaining stocks


### PR DESCRIPTION
- Clear statement cache when refreshing connections
- Remove auto-flush from BatchProcessor to make retry idempotent

*Issue #, if available:*

We noticed the TPCC loader may keep retrying with a stale prepared statement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
