### PR TITLE
Add Aurora DSQL foreign key support to TPC-C

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ This fork applies performance best practices and minor PostgreSQL compatibility 
 - Proper handling of Aurora DSQL's async-only index creation to prevent blocking operations
 
 ### 6. **Foreign Key Constraint Compatibility**
-- Aurora DSQL currently does not support foreign key constraints, and this fork automatically handles this limitation
-- Schema definitions are optimized to work without foreign key constraints while maintaining data integrity through application logic
+- Aurora DSQL supports native foreign key constraints, and the TPC-C schema includes all standard relationships
+- Referential integrity checks add reads and can cause retryable serialization conflicts under concurrent writes, so account for that cost when comparing benchmark results
 
 These enhancements ensure optimal performance and reliability when benchmarking Aurora DSQL, providing results that accurately reflect the database's capabilities in real-world scenarios.
 
@@ -77,7 +77,7 @@ aws dsql create-cluster --region ${REGION}
 ```bash
 export CLUSTER_ENDPOINT=<cluster_id>.dsql.<region>.on.aws
 export REGION=<region>
-java -jar benchbase.jar -b tpcc -c config/auroradsql/sample_tpcc_config.xml --create=true --load=true --execute=true --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" --region ${REGION}
+java -jar benchbase.jar -b tpcc -c config/auroradsql/sample_tpcc_config.xml --create=true --load=true --execute=true --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" --region ${REGION}
 ```
 
 The default configuration will setup a TPC-C run for 200 warehouses. To learn more about the config file changes and the benchmarking results, checkout this [wiki](https://github.com/amazon-contributing/aurora-dsql-benchbase-benchmarking/wiki#loading-data-and-running-tpc-c-against-an-aurora-dsql-cluster).
@@ -111,7 +111,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --skipMainDataLoad true \
     --scalefactor 200 \
@@ -131,7 +131,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --scalefactor 200 \
     --startWarehouseIndex 1 \
@@ -151,7 +151,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --scalefactor 200 \
     --startWarehouseIndex 2 \
@@ -171,7 +171,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --scalefactor 200 \
     --startWarehouseIndex 3 \
@@ -197,7 +197,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --scalefactor 200 \
     --startWarehouseIndex 1 \
@@ -217,7 +217,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --scalefactor 200 \
     --startWarehouseIndex 2 \
@@ -237,7 +237,7 @@ java \
     -jar benchbase.jar \
     -b tpcc \
     -c config/auroradsql/sample_tpcc_config.xml \
-    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=require&ApplicationName=tpcc&reWriteBatchedInserts=true" \
+    --url "jdbc:postgresql://${CLUSTER_ENDPOINT}:5432/postgres?sslmode=verify-full&ApplicationName=tpcc&reWriteBatchedInserts=true" \
     --region ${REGION} \
     --scalefactor 200 \
     --startWarehouseIndex 3 \

--- a/config/auroradsql/sample_tpcc_config.xml
+++ b/config/auroradsql/sample_tpcc_config.xml
@@ -4,7 +4,7 @@
     <!-- Connection details -->
     <type>AURORADSQL</type>
     <driver>org.postgresql.Driver</driver>
-    <url>jdbc:postgresql://localhost:5432/postgres?sslmode=require&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true</url>
+    <url>jdbc:postgresql://localhost:5432/postgres?sslmode=verify-full&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true</url>
 
     <!-- Extra Feature -->
     <!-- If username isn't provided, "admin" is used by default. -->

--- a/src/main/resources/benchmarks/tpcc/ddl-auroradsql.sql
+++ b/src/main/resources/benchmarks/tpcc/ddl-auroradsql.sql
@@ -48,7 +48,9 @@ CREATE TABLE stock (
     s_dist_08    char(24)      NOT NULL,
     s_dist_09    char(24)      NOT NULL,
     s_dist_10    char(24)      NOT NULL,
-    PRIMARY KEY (s_w_id, s_i_id)
+    PRIMARY KEY (s_w_id, s_i_id),
+    CONSTRAINT s_fkey_w FOREIGN KEY (s_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE,
+    CONSTRAINT s_fkey_i FOREIGN KEY (s_i_id) REFERENCES item (i_id) ON DELETE CASCADE
 );
 
 CREATE TABLE district (
@@ -63,7 +65,8 @@ CREATE TABLE district (
     d_city      varchar(20)    NOT NULL,
     d_state     char(2)        NOT NULL,
     d_zip       char(9)        NOT NULL,
-    PRIMARY KEY (d_w_id, d_id)
+    PRIMARY KEY (d_w_id, d_id),
+    CONSTRAINT d_fkey_w FOREIGN KEY (d_w_id) REFERENCES warehouse (w_id) ON DELETE CASCADE
 );
 
 CREATE TABLE customer (
@@ -88,7 +91,9 @@ CREATE TABLE customer (
     c_since        timestamp      NOT NULL DEFAULT CURRENT_TIMESTAMP,
     c_middle       char(2)        NOT NULL,
     c_data         varchar(500)   NOT NULL,
-    PRIMARY KEY (c_w_id, c_d_id, c_id)
+    PRIMARY KEY (c_w_id, c_d_id, c_id),
+    CONSTRAINT c_fkey_d
+        FOREIGN KEY (c_w_id, c_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE
 );
 
 CREATE TABLE history (
@@ -99,7 +104,11 @@ CREATE TABLE history (
     h_w_id   int           NOT NULL,
     h_date   timestamp     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     h_amount decimal(6, 2) NOT NULL,
-    h_data   varchar(24)   NOT NULL
+    h_data   varchar(24)   NOT NULL,
+    CONSTRAINT h_fkey_c
+        FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE,
+    CONSTRAINT h_fkey_d
+        FOREIGN KEY (h_w_id, h_d_id) REFERENCES district (d_w_id, d_id) ON DELETE CASCADE
 );
 
 CREATE TABLE oorder (
@@ -112,14 +121,18 @@ CREATE TABLE oorder (
     o_all_local  int       NOT NULL,
     o_entry_d    timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE (o_w_id, o_d_id, o_c_id, o_id),
-    PRIMARY KEY (o_w_id, o_d_id, o_id)
+    PRIMARY KEY (o_w_id, o_d_id, o_id),
+    CONSTRAINT o_fkey_c
+        FOREIGN KEY (o_w_id, o_d_id, o_c_id) REFERENCES customer (c_w_id, c_d_id, c_id) ON DELETE CASCADE
 );
 
 CREATE TABLE new_order (
     no_w_id int NOT NULL,
     no_d_id int NOT NULL,
     no_o_id int NOT NULL,
-    PRIMARY KEY (no_w_id, no_d_id, no_o_id)
+    PRIMARY KEY (no_w_id, no_d_id, no_o_id),
+    CONSTRAINT no_fkey_o
+        FOREIGN KEY (no_w_id, no_d_id, no_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE
 );
 
 CREATE TABLE order_line (
@@ -133,7 +146,11 @@ CREATE TABLE order_line (
     ol_supply_w_id int           NOT NULL,
     ol_quantity    decimal(6, 2) NOT NULL,
     ol_dist_info   char(24)      NOT NULL,
-    PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number)
+    PRIMARY KEY (ol_w_id, ol_d_id, ol_o_id, ol_number),
+    CONSTRAINT ol_fkey_o
+        FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id) REFERENCES oorder (o_w_id, o_d_id, o_id) ON DELETE CASCADE,
+    CONSTRAINT ol_fkey_s
+        FOREIGN KEY (ol_supply_w_id, ol_i_id) REFERENCES stock (s_w_id, s_i_id) ON DELETE CASCADE
 );
 
 CREATE INDEX ASYNC idx_customer_name ON customer (c_w_id, c_d_id, c_last, c_first);

--- a/src/test/java/com/oltpbenchmark/benchmarks/tpcc/TestAuroraDsqlDDL.java
+++ b/src/test/java/com/oltpbenchmark/benchmarks/tpcc/TestAuroraDsqlDDL.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 by OLTPBenchmark Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.oltpbenchmark.benchmarks.tpcc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.junit.Test;
+
+public class TestAuroraDsqlDDL {
+
+  private static final String DDL_RESOURCE = "/benchmarks/tpcc/ddl-auroradsql.sql";
+
+  @Test
+  public void testForeignKeyConstraints() throws IOException {
+    String ddl;
+    try (InputStream stream = getClass().getResourceAsStream(DDL_RESOURCE)) {
+      assertTrue("Missing " + DDL_RESOURCE, stream != null);
+      ddl = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    String normalizedDdl = ddl.toLowerCase().replaceAll("\\s+", " ");
+    List<String> constraints =
+        List.of(
+            "foreign key (s_w_id) references warehouse (w_id) on delete cascade",
+            "foreign key (s_i_id) references item (i_id) on delete cascade",
+            "foreign key (d_w_id) references warehouse (w_id) on delete cascade",
+            "foreign key (c_w_id, c_d_id) references district (d_w_id, d_id) on delete cascade",
+            "foreign key (h_c_w_id, h_c_d_id, h_c_id) references customer (c_w_id, c_d_id, c_id) on delete cascade",
+            "foreign key (h_w_id, h_d_id) references district (d_w_id, d_id) on delete cascade",
+            "foreign key (o_w_id, o_d_id, o_c_id) references customer (c_w_id, c_d_id, c_id) on delete cascade",
+            "foreign key (no_w_id, no_d_id, no_o_id) references oorder (o_w_id, o_d_id, o_id) on delete cascade",
+            "foreign key (ol_w_id, ol_d_id, ol_o_id) references oorder (o_w_id, o_d_id, o_id) on delete cascade",
+            "foreign key (ol_supply_w_id, ol_i_id) references stock (s_w_id, s_i_id) on delete cascade");
+
+    assertEquals(
+        "Unexpected number of Aurora DSQL foreign keys",
+        constraints.size(),
+        normalizedDdl.split("foreign key \\(", -1).length - 1);
+
+    for (String constraint : constraints) {
+      assertTrue(
+          "Missing Aurora DSQL constraint: " + constraint, normalizedDdl.contains(constraint));
+    }
+  }
+}

--- a/src/test/java/com/oltpbenchmark/util/TestIAMUtil.java
+++ b/src/test/java/com/oltpbenchmark/util/TestIAMUtil.java
@@ -16,7 +16,7 @@ public class TestIAMUtil {
   private AwsCredentialsProvider credentialsProvider;
   private DefaultAwsRegionProviderChain regionProvider;
   private static final String VALID_URL =
-      "jdbc:postgresql://localhost:5432/postgres?sslmode=require&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true";
+      "jdbc:postgresql://localhost:5432/postgres?sslmode=verify-full&amp;ApplicationName=tpcc&amp;reWriteBatchedInserts=true";
   private static final String VALID_ADMIN_USERNAME = "admin";
 
   @Before


### PR DESCRIPTION
## Summary

- add all 10 canonical TPC-C foreign key relationships to the Aurora DSQL schema
- use `ON DELETE CASCADE` to preserve BenchBase cleanup semantics
- document DSQL foreign key read and serialization-conflict costs
- upgrade sample JDBC URLs from `sslmode=require` to `sslmode=verify-full`
- add regression coverage for the exact foreign key set and cascade actions

## Validation

- executed the complete DDL in an isolated schema on an active Aurora DSQL cluster
- confirmed all 10 foreign keys were valid and configured for cascading deletes
- inserted a valid row through the complete TPC-C dependency graph
- confirmed an orphan stock row was rejected by `s_fkey_w`
- confirmed deleting a warehouse cascaded through all dependent tables while retaining the global item row
- removed the isolated validation schema afterward
- final Surefire reports: 236 tests, 231 passed, 5 skipped, 0 failures, 0 errors
- `git diff --check` passes

## Release review

Aurora DSQL added native foreign key support on August 26, 2026. Other recent releases reviewed (identity/sequences, JSON/JSONB, expanded `ALTER TABLE`, expression indexes, extended statistics, numeric improvements, and expanded locking clauses) do not require additional TPC-C schema or workload changes.